### PR TITLE
Fix type exports

### DIFF
--- a/types.js
+++ b/types.js
@@ -1,3 +1,5 @@
+module.exports._typesOnly = true;
+
 /**
  * @typedef LibAuth
  * @property {PromisifyHandler} promisifyHandler


### PR DESCRIPTION
`types.js` just needs to access `module.exports` in order to cause `tsc` to kick in its export machinery. So I added this:

```js
module.exports._typesOnly = true;
```