### PR TITLE
OIDC allow bespoke discovery

### DIFF
--- a/lib/oidc.js
+++ b/lib/oidc.js
@@ -125,7 +125,10 @@ OIDC.create = function (libauth, libOpts) {
       }
 
       //let oidcAuthUrl = "https://accounts.google.com/o/oauth2/v2/auth";
-      let oidcConfig = await OIDC.getConfig(pluginOpts.issuer);
+      let oidcConfig = await OIDC.getConfig(
+        pluginOpts.issuer,
+        pluginOpts.discoveryPath,
+      );
 
       // ex: https://app.example.com/api/authn/session/oidc/accounts.google.com/redirect
       let redirectUri =
@@ -211,7 +214,10 @@ OIDC.create = function (libauth, libOpts) {
     /** @type {import('express').Handler} */
     async function requestToken(req, res, next) {
       let oidcTokenRequest = libauth.get(req, "oidcRequest");
-      let oidcConfig = await OIDC.getConfig(pluginOpts.issuer);
+      let oidcConfig = await OIDC.getConfig(
+        pluginOpts.issuer,
+        pluginOpts.discoveryPath,
+      );
       // TODO get the code and exchange it
       let resp = await request({
         method: "POST",
@@ -323,13 +329,41 @@ async function mustOk(resp) {
 /** @type Record<String,OIDCCache> */
 OIDC._configs = {};
 
-/** @param {String} issuer */
-OIDC.getConfig = async function (issuer) {
+// Thanks to https://transform.tools/json-to-jsdoc
+/**
+ * @typedef OidcConfig
+ * @property {String} issuer
+ * @property {String} authorization_endpoint
+ * @property {String} device_authorization_endpoint
+ * @property {String} token_endpoint
+ * @property {String} userinfo_endpoint
+ * @property {String} revocation_endpoint
+ * @property {String} jwks_uri
+ * @property {Array<String>} response_types_supported
+ * @property {Array<String>} subject_types_supported
+ * @property {Array<String>} id_token_signing_alg_values_supported
+ * @property {Array<String>} scopes_supported
+ * @property {Array<String>} token_endpoint_auth_methods_supported
+ * @property {Array<String>} claims_supported
+ * @property {Array<String>} code_challenge_methods_supported
+ * @property {Array<String>} grant_types_supported
+ */
+
+/**
+ * Discover an issuer's oidc-configuration (from the well-known or a bespoke path)
+ * @param {String} issuer
+ * @param {String} [discoveryPath]
+ * @returns {Promise<OidcConfig>}
+ */
+OIDC.getConfig = async function (issuer, discoveryPath) {
   let oidcUrl = issuer;
   if (!oidcUrl.endsWith("/")) {
     oidcUrl += "/";
   }
-  oidcUrl += ".well-known/openid-configuration";
+  if (!discoveryPath) {
+    discoveryPath = ".well-known/openid-configuration";
+  }
+  oidcUrl += discoveryPath;
   if (OIDC._configs[oidcUrl]) {
     if (OIDC._configs[oidcUrl].exp - Date.now() > 0) {
       return OIDC._configs[oidcUrl].config;


### PR DESCRIPTION
new optional param `discoveryPath`

TODO:
- [ ] document in OIDC options
- [ ] consistency? should this be `discovery_path`?