### PR TITLE
fix(oidc): require 'Bearer ' prefix for implicit grant flow

### DIFF
--- a/lib/magic.js
+++ b/lib/magic.js
@@ -93,12 +93,12 @@ Magic.create = function (libauth, libOpts) {
       }
 
       let id =
-        req.params.id || req.body.id || req.query.id || req.params.challenge_id;
-      let code = req.body.code || req.query.code;
-      let receipt = req.body.receipt || req.query.receipt;
-      let finalize = req.body.finalize || req.query.finalize;
-      let identifier = req.body.identifier;
-      let state = req.body.state;
+        req.params.id || req.body?.id || req.query.id || req.params.challenge_id;
+      let code = req.body?.code || req.query.code;
+      let receipt = req.body?.receipt || req.query.receipt;
+      let finalize = req.body?.finalize || req.query.finalize;
+      let identifier = req.body?.identifier;
+      let state = req.body?.state;
 
       let userAgent = req.headers["user-agent"] || "";
       let ip = req.ip || "";

--- a/lib/oidc.js
+++ b/lib/oidc.js
@@ -183,10 +183,18 @@ OIDC.create = function (libauth, libOpts) {
       next();
     }
 
+    const BEARER_PREFIX = "Bearer ";
+
     /** @type {import('express').Handler} */
     async function verifyToken(req, res, next) {
       // For POST 'Implicit Grant' (Client-Side) Flow
-      let jwt = (req.headers.authorization || "").replace(/^Bearer /, "");
+      let jwt = req.headers.authorization || "";
+      let isBearer = jwt.startsWith(BEARER_PREFIX);
+      if (isBearer) {
+        jwt = jwt.slice(BEARER_PREFIX.length);
+      } else {
+        jwt = "";
+      }
 
       if (!jwt) {
         // For GET 'Authorization Code' (Server-Side Redirects) Flow

--- a/lib/session.js
+++ b/lib/session.js
@@ -326,8 +326,8 @@ LibAuth.create = function (issuer, PRIVATE_KEY, myOptions) {
         let userKey = credOpts.username || "username";
         let passKey = credOpts.password || "password";
         creds = {
-          username: req.body[userKey],
-          password: req.body[passKey],
+          username: req.body?.[userKey],
+          password: req.body?.[passKey],
         };
       }
 
@@ -513,7 +513,7 @@ LibAuth.create = function (issuer, PRIVATE_KEY, myOptions) {
 
     let sessionMaxAge = libOpts.sessionMaxAge;
     // TODO is this really the best place for trust_device?
-    if (req.body.trust_device) {
+    if (req.body?.trust_device) {
       sessionMaxAge = libOpts.trustedMaxAge || libOpts.refreshMaxAge;
     }
     sessionClaims = Object.assign(
@@ -851,7 +851,7 @@ LibAuth.create = function (issuer, PRIVATE_KEY, myOptions) {
    * @param {Number} epoch
    */
   function _assertMaxAge(req, epoch) {
-    let maxAgeStr = req.body.max_age || req.query.max_age;
+    let maxAgeStr = req.body?.max_age || req.query.max_age;
     if (!maxAgeStr) {
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libauth",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libauth",
-      "version": "0.20.5",
+      "version": "0.20.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/cookie-parser": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libauth",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "Modern, OpenID Connect compatible authentication.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This is for a development site behind a simple HTTP Basic Auth-wall.

The login flow isn't finished yet, so this created a catch-22, preventing testing login flow.