### PR TITLE
ref(jwt): cleanup bytes vs binstr vs utf8

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -173,11 +173,13 @@ JWT.sign = async function (privateKeyJwk, opts) {
 
   let sortedHeader = JWT._shallowCanonicalCopy(header);
   let headerJson = JSON.stringify(sortedHeader);
-  let headerB64 = JWT._binstrToUrlBase64(headerJson);
+  let headerBytes = JWT._textEncoder.encode(headerJson);
+  let headerB64 = JWT._bytesToUrlBase64(headerBytes);
 
   let sortedPayload = JWT._shallowCanonicalCopy(claims);
   let payloadJson = JSON.stringify(sortedPayload);
-  let payloadB64 = JWT._utf8ToUrlBase64(payloadJson);
+  let payloadBytes = JWT._textEncoder.encode(payloadJson);
+  let payloadB64 = JWT._bytesToUrlBase64(payloadBytes);
 
   let key = await crypto.subtle.importKey(
     "jwk",
@@ -191,9 +193,7 @@ JWT.sign = async function (privateKeyJwk, opts) {
   let inputBytes = JWT._textEncoder.encode(input);
   let signatureAb = await crypto.subtle.sign(signAlgo, key, inputBytes);
   let signatureBytes = new Uint8Array(signatureAb);
-  //@ts-expect-error - Uint8Array is ArrayLike
-  let signatureBin = String.fromCharCode.apply(null, signatureBytes);
-  let signatureB64 = JWT._binstrToUrlBase64(signatureBin);
+  let signatureB64 = JWT._bytesToUrlBase64(signatureBytes);
 
   let jwt = `${input}.${signatureB64}`;
   return jwt;
@@ -209,6 +209,7 @@ JWT._shallowCanonicalCopy = function (obj) {
 
   let keys = Object.keys(obj).sort();
   for (let key of keys) {
+    //@ts-expect-error anyish on purpose
     copy[key] = obj[key];
   }
 
@@ -279,9 +280,7 @@ JWT.thumbprint = async function (jwk) {
   let bytes = JWT._textEncoder.encode(sortedJson);
   let hashAb = await crypto.subtle.digest("SHA-256", bytes);
   let hashBytes = new Uint8Array(hashAb);
-  //@ts-expect-error - Uint8Array is ArrayLike
-  let bin = String.fromCharCode.apply(null, hashBytes);
-  let base64 = JWT._binstrToUrlBase64(bin);
+  let base64 = JWT._bytesToUrlBase64(hashBytes);
 
   return base64;
 };
@@ -308,11 +307,11 @@ function isJWKRSA(jwk) {
 
 /**
  * Encode to Base64 URL-safe string
- * @param {UTF8Str} utf8
+ * @param {Array<Number>|Uint8Array} bytes
  * @returns {URLBase64}
  */
-JWT._utf8ToUrlBase64 = function (utf8) {
-  let bytes = JWT._textEncoder.encode(utf8);
+JWT._bytesToUrlBase64 = function (bytes) {
+  //@ts-expect-error
   let bin = String.fromCharCode.apply(null, bytes);
   let b64 = JWT._binstrToUrlBase64(bin);
   return b64;


### PR DESCRIPTION
Encode utf8 => bytes => binstr => base64 more cleanly.