### PR TITLE
fix: actually set 'finalized_at' on 'finalize'

### DIFF
--- a/lib/magic-flow.js
+++ b/lib/magic-flow.js
@@ -120,9 +120,7 @@ MagicFlow.create = function (_pluginOpts) {
       order.verified_by = device.userAgent;
       order.verified_ip = device.ip;
       if (params.finalize) {
-        order.exchanged_at = nowStr;
-        //order.exchanged_by = "";
-        //order.exchanged_ip = "";
+        order.finalized_at = nowStr;
       }
       return order;
     }
@@ -136,6 +134,14 @@ MagicFlow.create = function (_pluginOpts) {
         );
       }
       */
+
+      if (!order.verified_at) {
+        // TODO better message and error code
+        throw E.DEVELOPER_ERROR(
+          "a challenge code exchange was requested before the challenge code was submitted",
+        );
+      }
+
       if (order.finalized_at) {
         throw E.DEVELOPER_ERROR("the challenge has already been finalized");
       }
@@ -148,14 +154,6 @@ MagicFlow.create = function (_pluginOpts) {
         throw E.SUSPICIOUS_REQUEST();
       }
 
-      if (!order.verified_at) {
-        // TODO better message and error code
-        throw E.DEVELOPER_ERROR(
-          "a challenge code exchange was requested before the challenge code was submitted",
-        );
-      }
-
-      /* if (order.exchanged_at) { throw E_CODE_REDEEMED } */
       if (params.receipt) {
         order.exchanged_at = nowStr;
         //order.exchanged_by = device.userAgent;

--- a/lib/magic-flow.js
+++ b/lib/magic-flow.js
@@ -103,14 +103,13 @@ MagicFlow.create = function (_pluginOpts) {
     let nowStr = new Date().toISOString();
 
     if (params.code) {
-      /*
-      // TODO maybe?
+      // checking because it's possible to use .exchange (which calls .redeem) incorrectly
       if (!validations.code) {
         throw E.DEVELOPER_ERROR(
           "@libauth/magic: tried to redeem an non-verified response",
         );
       }
-      */
+
       if (order.verified_at) {
         // TODO is this not also a developer error?
         throw E.CODE_REDEEMED();
@@ -126,15 +125,6 @@ MagicFlow.create = function (_pluginOpts) {
     }
 
     if (params.receipt || params.finalize) {
-      /*
-      // TODO maybe?
-      if (!validations.code) {
-        throw E.DEVELOPER_ERROR(
-          "@libauth/magic: tried to redeem an non-verified response",
-        );
-      }
-      */
-
       if (!order.verified_at) {
         // TODO better message and error code
         throw E.DEVELOPER_ERROR(

--- a/lib/magic.js
+++ b/lib/magic.js
@@ -262,7 +262,6 @@ Magic.create = function (libauth, libOpts) {
       // Both `code` and `receipt` function as one-time passwords
       // for a single token exchange, but they can be used multiple
       // times for status checks.
-      // if (!magic.validations.valid) {
       if (magic.validations.code || magic.validations.receipt) {
         next();
         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libauth",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libauth",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/cookie-parser": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libauth",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Modern, OpenID Connect compatible authentication.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
There was some confusion between `exchanged_at` and `finalized_at` at some point in the past.

The result is that the `finalize` that would cancel the `receipt` was not enforced - so the `receipt` could still be used on the original device.

Not a huge deal - because both the device that ordered the auth and the device that completed the challenge are trusted by the user - but not good either.